### PR TITLE
Community event modal: fix banner overlap, add YouTube embeds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "DOCKERHUB",
         "formspree",
         "geist",
-        "netconf"
+        "netconf",
+        "Youtube"
     ]
 }

--- a/app/[locale]/community/CommunityContent.tsx
+++ b/app/[locale]/community/CommunityContent.tsx
@@ -174,18 +174,18 @@ export default function CommunityContent() {
               <DialogDescription>{selectedEvent.role}</DialogDescription>
             </DialogHeader>
 
-            <div className="relative w-full aspect-video rounded-lg overflow-hidden">
-              <Image
-                src={selectedEvent.thumbnail}
-                alt={selectedEvent.title}
-                fill
-                className="object-cover"
-                placeholder="blur"
-                blurDataURL={shimmerBlurDataURL}
-              />
-            </div>
-
             <div className="space-y-6">
+              <div className="relative w-full aspect-video rounded-lg overflow-hidden">
+                <Image
+                  src={selectedEvent.thumbnail}
+                  alt={selectedEvent.title}
+                  fill
+                  className="object-cover"
+                  placeholder="blur"
+                  blurDataURL={shimmerBlurDataURL}
+                />
+              </div>
+
               {/* Meta Info */}
               {(selectedEvent.location || selectedEvent.startDate || selectedEvent.frequency || selectedEvent.year) && (
                 <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">

--- a/app/[locale]/community/CommunityContent.tsx
+++ b/app/[locale]/community/CommunityContent.tsx
@@ -4,12 +4,32 @@ import { useState } from "react"
 import Image from "next/image"
 import { Badge } from "@/components/ui/badge"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { ExternalLink, Github, Users, Calendar, Award, Mic, MapPin, Heart } from "lucide-react"
+import { ExternalLink, Github, Users, Calendar, Award, Mic, MapPin, Heart, Youtube } from "lucide-react"
 import LottieAnimation from "@/components/LottieAnimation"
 import { Event } from "@/types/Event"
 import { speakingAndEvents } from "@/data/events"
 import { shimmerBlurDataURL } from "@/lib/image"
 import { useTranslations } from "next-intl"
+
+function getYoutubeEmbedUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.replace(/^www\./, "");
+    let id: string | null = null;
+    if (host === "youtu.be") {
+      id = parsed.pathname.slice(1);
+    } else if (host.endsWith("youtube.com") || host.endsWith("youtube-nocookie.com")) {
+      if (parsed.pathname === "/watch") {
+        id = parsed.searchParams.get("v");
+      } else if (parsed.pathname.startsWith("/embed/") || parsed.pathname.startsWith("/shorts/")) {
+        id = parsed.pathname.split("/")[2] ?? null;
+      }
+    }
+    return id ? `https://www.youtube-nocookie.com/embed/${id}` : null;
+  } catch {
+    return null;
+  }
+}
 
 export default function CommunityContent() {
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
@@ -244,6 +264,34 @@ export default function CommunityContent() {
                       {link.label}
                     </a>
                   ))}
+                </div>
+              )}
+
+              {/* Videos */}
+              {selectedEvent.videos && selectedEvent.videos.length > 0 && (
+                <div>
+                  <h4 className="font-medium mb-3 flex items-center gap-2">
+                    <Youtube className="w-4 h-4" />
+                    {t('dialog.videos')}
+                  </h4>
+                  <div className="space-y-4">
+                    {selectedEvent.videos.map((video, idx) => {
+                      const embedUrl = getYoutubeEmbedUrl(video);
+                      if (!embedUrl) return null;
+                      return (
+                        <div key={idx} className="relative aspect-video rounded-lg overflow-hidden bg-muted">
+                          <iframe
+                            src={embedUrl}
+                            title={`${selectedEvent.title} - Video ${idx + 1}`}
+                            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allowFullScreen
+                            loading="lazy"
+                            className="absolute inset-0 w-full h-full border-0"
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
 

--- a/data/events.ts
+++ b/data/events.ts
@@ -111,6 +111,7 @@ export const speakingAndEvents: Event[] = [
       "/assets/events/infinite-days/image-10.jpeg",
       "/assets/events/infinite-days/image-11.jpeg",
     ],
+    videos: ["https://youtu.be/pTMKz5mv81Q"],
     status: "completed",
     highlights: [
       "Explored emerging technologies and their practical applications",

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,6 +141,7 @@
     "dialog": {
       "about": "About",
       "highlights": "Highlights",
+      "videos": "Videos",
       "gallery": "Gallery"
     },
     "getInvolved": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -141,6 +141,7 @@
     "dialog": {
       "about": "À propos",
       "highlights": "Points Forts",
+      "videos": "Vidéos",
       "gallery": "Galerie"
     },
     "getInvolved": {

--- a/types/Event.ts
+++ b/types/Event.ts
@@ -10,6 +10,7 @@ export interface Event {
   startDate?: string;
   thumbnail: string;
   gallery?: string[];
+  videos?: string[];
   highlights?: string[];
   links?: { label: string; url: string }[];
   status: "ongoing" | "completed" | "upcoming";


### PR DESCRIPTION
## Summary
- Fix the community event detail modal where the banner image could overlap the description/highlights when content scrolled — by moving the image inside the existing `space-y-6` wrapper so it is no longer a direct child of `DialogContent`'s grid layout.
- Add an optional `videos?: string[]` field to `Event` and render a new "Videos" section in the modal between Links and Gallery. URLs are normalized to `youtube-nocookie.com/embed/<id>` and rendered as responsive, lazy-loaded, fullscreen-enabled iframes.
- Wire up the Infinite Days 2023 talk recording.
- Add the `Community.dialog.videos` translation in en/fr.

## Test plan
- [x] Open `/community`, click any event card without videos — the modal renders with no Videos section and content/banner do not overlap when scrolling.
- [x] Open the Infinite Days 2023 event — the Videos section renders with a playable YouTube iframe, content does not overlap the banner.
- [x] Switch to `/fr/community` and confirm the section heading shows "Vidéos".
- [x] Try adding a `watch?v=`, `youtu.be/`, and `/shorts/` URL locally and confirm each embeds correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)