### PR TITLE
Add Utauro to home activity feed

### DIFF
--- a/data/activities.ts
+++ b/data/activities.ts
@@ -21,5 +21,20 @@ export const activities: Activity[] = [
       label: "Submit a Session",
       external: true,
     },
+  },
+  {
+    id: "building-utauro",
+    date: "2026-12-11",
+    when: "In progress",
+    status: "ongoing",
+    tag: "Building",
+    title: "Building Utauro",
+    description:
+      "I'm currently building Utauro — a local-first, privacy-focused macOS app that automatically tracks how you spend time on your Mac. No timers or manual tagging: it quietly records app and document usage, then breaks your day down into meaningful activity categories, all stored on-device. Waitlist is open.",
+    link: {
+      href: "https://utauro.app",
+      label: "Join The Waitlist",
+      external: true,
+    },
   }
 ];


### PR DESCRIPTION
Adds an ongoing activity entry to the home page feed announcing that I'm currently building [Utauro](https://utauro.app), a local-first, privacy-focused macOS time-tracking app. Includes a description of what it is and a waitlist link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)