### PR TITLE
Show multiple roles per company in experience section

### DIFF
--- a/app/[locale]/widgets/ExperienceSection.tsx
+++ b/app/[locale]/widgets/ExperienceSection.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import JobExperienceCard from "./JobExperienceCard";
 import { experiences } from "@/data/experiences";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 export default async function ExperienceSection() {
   const t = await getTranslations('Experience');
+  const locale = await getLocale();
 
   return (
     <section className="section py-16">
@@ -15,7 +16,12 @@ export default async function ExperienceSection() {
             <div key={e.id.toString()}>
               <JobExperienceCard
                 model={e}
-                translations={{ at: t('at'), present: t('present') }}
+                locale={locale}
+                translations={{
+                  present: t('present'),
+                  current: t('current'),
+                  promoted: t('promoted'),
+                }}
               />
             </div>
           ))}

--- a/app/[locale]/widgets/ExperienceSection.tsx
+++ b/app/[locale]/widgets/ExperienceSection.tsx
@@ -20,7 +20,6 @@ export default async function ExperienceSection() {
                 translations={{
                   present: t('present'),
                   current: t('current'),
-                  promoted: t('promoted'),
                 }}
               />
             </div>

--- a/app/[locale]/widgets/JobExperienceCard.tsx
+++ b/app/[locale]/widgets/JobExperienceCard.tsx
@@ -101,11 +101,6 @@ function RoleEntry({
             {translations.current}
           </span>
         )}
-        {showTimeline && isLatest && role.end && (
-          <span className="text-[11px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-foreground/10 text-foreground">
-            {translations.promoted}
-          </span>
-        )}
         <span className="text-sm text-muted-foreground">
           {formatMonthYear(role.start, locale)} -{" "}
           {role.end ? formatMonthYear(role.end, locale) : translations.present}
@@ -129,6 +124,5 @@ export interface JobExperienceProps {
   translations: {
     present: string;
     current: string;
-    promoted: string;
   };
 }

--- a/app/[locale]/widgets/JobExperienceCard.tsx
+++ b/app/[locale]/widgets/JobExperienceCard.tsx
@@ -1,9 +1,18 @@
-import { JobExperience } from "@/types/JobExperience";
+import { JobExperience, JobRole } from "@/types/JobExperience";
 import { Link } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 
-export default function JobExperienceCard({ model, translations }: JobExperienceProps) {
+function formatMonthYear(date: Date, locale: string) {
+  return date.toLocaleDateString(locale, { month: "short", year: "numeric" });
+}
+
+export default function JobExperienceCard({ model, locale, translations }: JobExperienceProps) {
+  const roles = model.roles;
+  const latest = roles[0];
+  const oldest = roles[roles.length - 1];
+  const hasProgression = roles.length > 1;
+
   return (
     <div className="flex flex-col md:flex-row justify-between gap-6 py-4 border-b border-border last:border-0">
       <div className="flex-1">
@@ -14,29 +23,39 @@ export default function JobExperienceCard({ model, translations }: JobExperience
             href={model.website}
           >
             <Link className="w-4 h-4" />
-            <span className="font-medium">{model.jobTitle}</span>
-            <span className="text-muted-foreground">{translations.at} {model.company}</span>
+            <span className="font-medium">{model.company}</span>
           </a>
           <span className="text-sm text-muted-foreground">
-            {model.start.getFullYear()} - {model.end ? model.end.getFullYear() : translations.present}
+            {oldest.start.getFullYear()} -{" "}
+            {latest.end ? latest.end.getFullYear() : translations.present}
           </span>
         </div>
         <p className="text-muted-foreground mb-4">{model.jobDescription}</p>
-        <ul className="space-y-2">
-          {model.responsibilities.map((r, index) => (
-            <li key={index} className="flex items-start gap-2 text-sm">
-              <span className="text-muted-foreground mt-1">•</span>
-              <span>{r}</span>
-            </li>
-          ))}
-        </ul>
+
+        <div className={hasProgression ? "relative pl-6" : ""}>
+          {hasProgression && (
+            <span
+              className="absolute left-[3px] top-2 bottom-2 w-px bg-border"
+              aria-hidden
+            />
+          )}
+          <div className="space-y-5">
+            {roles.map((role, index) => (
+              <RoleEntry
+                key={index}
+                role={role}
+                locale={locale}
+                showTimeline={hasProgression}
+                isCurrent={index === 0}
+                isLatest={index === 0}
+                translations={translations}
+              />
+            ))}
+          </div>
+        </div>
       </div>
       <div className="flex-shrink-0">
-        <a
-          href={model.website}
-          target="_blank"
-          className="block"
-        >
+        <a href={model.website} target="_blank" className="block">
           <Image
             src={model.logo}
             alt={`${model.company}'s Logo`}
@@ -50,10 +69,66 @@ export default function JobExperienceCard({ model, translations }: JobExperience
   );
 }
 
+function RoleEntry({
+  role,
+  locale,
+  showTimeline,
+  isCurrent,
+  isLatest,
+  translations,
+}: {
+  role: JobRole;
+  locale: string;
+  showTimeline: boolean;
+  isCurrent: boolean;
+  isLatest: boolean;
+  translations: JobExperienceProps["translations"];
+}) {
+  return (
+    <div className="relative">
+      {showTimeline && (
+        <span
+          className={`absolute -left-6 top-1.5 w-[7px] h-[7px] rounded-full ring-4 ring-background ${
+            isCurrent ? "bg-foreground" : "bg-muted-foreground/40"
+          }`}
+          aria-hidden
+        />
+      )}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="font-medium">{role.jobTitle}</span>
+        {showTimeline && isLatest && !role.end && (
+          <span className="text-[11px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-foreground/10 text-foreground">
+            {translations.current}
+          </span>
+        )}
+        {showTimeline && isLatest && role.end && (
+          <span className="text-[11px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-foreground/10 text-foreground">
+            {translations.promoted}
+          </span>
+        )}
+        <span className="text-sm text-muted-foreground">
+          {formatMonthYear(role.start, locale)} -{" "}
+          {role.end ? formatMonthYear(role.end, locale) : translations.present}
+        </span>
+      </div>
+      <ul className="space-y-2 mt-2">
+        {role.responsibilities.map((r, index) => (
+          <li key={index} className="flex items-start gap-2 text-sm">
+            <span className="text-muted-foreground mt-1">•</span>
+            <span>{r}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export interface JobExperienceProps {
   model: JobExperience;
+  locale: string;
   translations: {
-    at: string;
     present: string;
+    current: string;
+    promoted: string;
   };
 }

--- a/data/experiences.ts
+++ b/data/experiences.ts
@@ -29,21 +29,27 @@ export const experiences: JobExperience[] = [
     roles: [
       {
         jobTitle: "Software Engineer II",
-        start: new Date(2025, 8, 1),
+        start: new Date(2026, 1, 1),
         end: new Date(2026, 6, 1),
         responsibilities: [
-          "Led the design of enterprise level backend systems",
-          "Mentored junior engineers and reviewed technical designs",
+          "Led the implementation of products end to end",
+          "Designed complex architectures and workflows",
+          "Managed team members and owned the quality of the outcome",
+          "Managed deadlines and client communication",
+          "Mentored interns"
         ],
       },
       {
         jobTitle: "Software Engineer",
-        start: new Date(2025, 2, 1),
-        end: new Date(2025, 8, 1),
+        start: new Date(2025, 1, 1),
+        end: new Date(2026, 1, 1),
         responsibilities: [
-          "Building enterprise level backend systems",
-          "Exchanging with customers to ensure the solutions we provide fit their needs",
-          "Writing technical documents and requirements papers",
+          "Explored a wide range of topics, from frontend to backend, AI and design",
+          "Maintained legacy .NET applications",
+          "Built real-world projects with Next.js",
+          "Designed a complete website in Figma",
+          "Adopted agent-based workflows with modern AI tools",
+          "Wrote technical documents",
         ],
       },
     ],

--- a/data/experiences.ts
+++ b/data/experiences.ts
@@ -10,11 +10,15 @@ export const experiences: JobExperience[] = [
       "A leading logistics operator in Africa, providing integrated transport, port, and supply chain solutions across the continent",
     roles: [
       {
-        jobTitle: "Software Engineer",
+        jobTitle: "Senior Software Engineer",
         start: new Date(2026, 6, 1),
         responsibilities: [
-          "Building and maintaining software solutions to support logistics operations",
-          "Collaborating with cross-functional teams to deliver reliable systems",
+          "Own features from design to delivery with a high degree of autonomy",
+          "Turn business needs into clear technical solutions across the domain",
+          "Lead the implementation of new services for internal needs",
+          "Migrate legacy software to modern microservices",
+          "Maintain and evolve existing microservices",
+          "Enforce quality on deliverables, where the impact of the systems is critical",
         ],
       },
     ],

--- a/data/experiences.ts
+++ b/data/experiences.ts
@@ -6,13 +6,17 @@ export const experiences: JobExperience[] = [
     company: "Africa Global Logistics",
     website: "https://www.aglgroup.com",
     logo: "/assets/agl.png",
-    jobTitle: "Software Engineer",
     jobDescription:
       "A leading logistics operator in Africa, providing integrated transport, port, and supply chain solutions across the continent",
-    start: new Date(2026, 6, 1),
-    responsibilities: [
-      "Building and maintaining software solutions to support logistics operations",
-      "Collaborating with cross-functional teams to deliver reliable systems",
+    roles: [
+      {
+        jobTitle: "Software Engineer",
+        start: new Date(2026, 6, 1),
+        responsibilities: [
+          "Building and maintaining software solutions to support logistics operations",
+          "Collaborating with cross-functional teams to deliver reliable systems",
+        ],
+      },
     ],
   },
   {
@@ -20,15 +24,28 @@ export const experiences: JobExperience[] = [
     company: "ST Digital",
     website: "https://st.digital",
     logo: "/assets/st-digital.png",
-    jobTitle: "Software Engineer",
     jobDescription:
       "A digital services company aiming to lead in digital transformation and cloud services",
-    start: new Date(2025, 2, 1),
-    end: new Date(2026, 6, 1),
-    responsibilities: [
-      "Building enterprise level backend systems",
-      "Exchanging with customers to ensure the solutions we provide fit their needs",
-      "Writing technical documents and requirements papers",
+    roles: [
+      {
+        jobTitle: "Software Engineer II",
+        start: new Date(2025, 8, 1),
+        end: new Date(2026, 6, 1),
+        responsibilities: [
+          "Led the design of enterprise level backend systems",
+          "Mentored junior engineers and reviewed technical designs",
+        ],
+      },
+      {
+        jobTitle: "Software Engineer",
+        start: new Date(2025, 2, 1),
+        end: new Date(2025, 8, 1),
+        responsibilities: [
+          "Building enterprise level backend systems",
+          "Exchanging with customers to ensure the solutions we provide fit their needs",
+          "Writing technical documents and requirements papers",
+        ],
+      },
     ],
   },
   {
@@ -36,13 +53,17 @@ export const experiences: JobExperience[] = [
     company: "L'Agence Digitale",
     website: "https://l-agence.digital",
     logo: "/assets/agence-digitale.png",
-    jobTitle: ".NET Developer",
     jobDescription: "IT solutions development firm",
-    start: new Date(2024, 2, 1),
-    end: new Date(2025, 2, 1),
-    responsibilities: [
-      "Performed migration of legacy .NET Applications from .NET Core 3.1 to .NET 8",
-      "Maintained legacy applications",
+    roles: [
+      {
+        jobTitle: ".NET Developer",
+        start: new Date(2024, 2, 1),
+        end: new Date(2025, 2, 1),
+        responsibilities: [
+          "Performed migration of legacy .NET Applications from .NET Core 3.1 to .NET 8",
+          "Maintained legacy applications",
+        ],
+      },
     ],
   },
   {
@@ -50,14 +71,18 @@ export const experiences: JobExperience[] = [
     company: "Infinite Solutions SARL",
     website: "https://isolutions-intl.com",
     logo: "/assets/infinite-solutions.png",
-    jobTitle: "Mobile Developer",
     jobDescription: "IT solutions development firm",
-    start: new Date(2022, 2, 1),
-    end: new Date(2024, 2, 1),
-    responsibilities: [
-      "Learnt .NET MAUI to build robust cross platform mobile applications",
-      "Built Desktop applications with Windows Forms",
-      "Built APIs with ASP.NET Core",
+    roles: [
+      {
+        jobTitle: "Mobile Developer",
+        start: new Date(2022, 2, 1),
+        end: new Date(2024, 2, 1),
+        responsibilities: [
+          "Learnt .NET MAUI to build robust cross platform mobile applications",
+          "Built Desktop applications with Windows Forms",
+          "Built APIs with ASP.NET Core",
+        ],
+      },
     ],
   },
   {
@@ -65,10 +90,14 @@ export const experiences: JobExperience[] = [
     company: "C-Dreams",
     website: "https://github.com/cdreams-gamedev",
     logo: "/assets/c-dreams.png",
-    jobTitle: "Game Developer Intern",
     jobDescription: "C-Dream is a Cameroonian team of game developers",
-    start: new Date(2021, 2, 1),
-    end: new Date(2022, 2, 1),
-    responsibilities: ["Learnt Unity3D"],
+    roles: [
+      {
+        jobTitle: "Game Developer Intern",
+        start: new Date(2021, 2, 1),
+        end: new Date(2022, 2, 1),
+        responsibilities: ["Learnt Unity3D"],
+      },
+    ],
   },
 ];

--- a/messages/en.json
+++ b/messages/en.json
@@ -62,8 +62,7 @@
     "heading": "Professional Experience",
     "present": "Present",
     "at": "at",
-    "current": "Current",
-    "promoted": "Promoted"
+    "current": "Current"
   },
   "FeaturedProjects": {
     "heading": "Featured Projects",

--- a/messages/en.json
+++ b/messages/en.json
@@ -61,7 +61,9 @@
   "Experience": {
     "heading": "Professional Experience",
     "present": "Present",
-    "at": "at"
+    "at": "at",
+    "current": "Current",
+    "promoted": "Promoted"
   },
   "FeaturedProjects": {
     "heading": "Featured Projects",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -61,7 +61,9 @@
   "Experience": {
     "heading": "Expérience Professionnelle",
     "present": "Présent",
-    "at": "chez"
+    "at": "chez",
+    "current": "Actuel",
+    "promoted": "Promu"
   },
   "FeaturedProjects": {
     "heading": "Projets Phares",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -62,8 +62,7 @@
     "heading": "Expérience Professionnelle",
     "present": "Présent",
     "at": "chez",
-    "current": "Actuel",
-    "promoted": "Promu"
+    "current": "Actuel"
   },
   "FeaturedProjects": {
     "heading": "Projets Phares",

--- a/types/JobExperience.ts
+++ b/types/JobExperience.ts
@@ -6,7 +6,7 @@ export interface JobRole {
 };
 
 export interface JobExperience {
-  id: Number,
+  id: number,
   company: string,
   website: string,
   logo: string,

--- a/types/JobExperience.ts
+++ b/types/JobExperience.ts
@@ -1,11 +1,17 @@
+export interface JobRole {
+  jobTitle: string,
+  start: Date,
+  end?: Date,
+  responsibilities: string[]
+};
+
 export interface JobExperience {
   id: Number,
   company: string,
   website: string,
   logo: string,
-  jobTitle: string,
   jobDescription: string,
-  start: Date,
-  end?: Date,
-  responsibilities: string[]
+  // Ordered from most recent to oldest. Multiple entries represent a
+  // progression within the same company (e.g. a promotion).
+  roles: JobRole[]
 };


### PR DESCRIPTION
## Summary
Reworks the home page experience section so a single company can display a **progression of roles** (e.g. a promotion), instead of one flat entry per position.

- **Data model** (`types/JobExperience.ts`): a `JobExperience` now describes the company and holds an ordered `roles: JobRole[]` (most recent first); each `JobRole` carries its own title, dates, and responsibilities.
- **Card UI** (`JobExperienceCard.tsx`): company header with the overall date span, and — when there's more than one role — a **vertical timeline** connecting the roles, the current one marked with a filled dot and a "Current" badge. Single-role companies render clean with no timeline chrome. Role dates use month + year, localized to the active locale.
- **Content**: updated ST Digital (Software Engineer → Software Engineer II) and AGL (Senior Software Engineer) with accurate dates and responsibilities.
- **i18n**: added the `current` key to `en.json` / `fr.json`.

## Test plan
- [x] `yarn type-check` passes
- [x] Visual check on the home page (ST Digital shows the two-role progression; single-role companies unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)